### PR TITLE
hotfix: resolve custom bots causing library crash at startup

### DIFF
--- a/poe-api/src/poe.py
+++ b/poe-api/src/poe.py
@@ -114,7 +114,7 @@ class Client:
 
     bots = {}
     for bot in bot_list:
-      chat_data = self.get_bot(bot["displayName"].lower())
+      chat_data = self.get_bot(bot["displayName"])
       bots[chat_data["defaultBotObject"]["nickname"]] = chat_data
           
     return bots


### PR DESCRIPTION
When the user added a custom bot, the program crashed at startup.

The problem came from the `get_bots()` function. It was trying to retrieve the bot via the `get_bot(display_name)` function. But the `display_name` had a `.lower()` in it, so the request to retrieve the custom bots was failing because the file name is case sensitive.
For example the file `CustomBot.json` exists, but not `custombot.json`.

This also fixes the problem of issue #27.

WARNING: If the custom bot is deleted, it will still be accessible and in the list, but it will be impossible to send it messages.
This can be easily fixed by taking into account only the bots that are not deleted, for example with the following code:
```py
def get_bots(self):
    viewer = self.next_data["props"]["pageProps"]["payload"]["viewer"]
    if not "availableBots" in viewer:
      raise RuntimeError("Invalid token.")
    bot_list = viewer["availableBots"]

    bots = {}
    for bot in bot_list:
      if bot["deletionState"] != "not_deleted": # A simple condition can be enough
        continue

      chat_data = self.get_bot(bot["displayName"])
      bots[chat_data["defaultBotObject"]["nickname"]] = chat_data
          
    return bots
```