### PR TITLE
Fix chat break KeyError

### DIFF
--- a/poe-api/src/poe.py
+++ b/poe-api/src/poe.py
@@ -522,7 +522,7 @@ class Client:
     result = self.send_query("AddMessageBreakMutation", {
       "chatId": self.get_bot_by_codename(chatbot)["chatId"]}
     )
-    return result["data"]["messageBreakCreate"]["message"]
+    return result["data"]["messageBreakEdgeCreate"]["message"]
 
   def get_message_history(self, chatbot, count=25, cursor=None):
     logger.info(f"Downloading {count} messages from {chatbot}")


### PR DESCRIPTION
Fix an error when trying to call chat break:
```py
client.send_chat_break(CHATBOT)
```

Error:
```py
KeyError: 'messageBreakCreate'
```