### PR TITLE
bugfix "payload" keyword error 

### DIFF
--- a/poe-api/src/poe.py
+++ b/poe-api/src/poe.py
@@ -195,7 +195,10 @@ class Client:
 
     if overwrite_vars:
       self.formkey = self.extract_formkey(r.text)
-      self.viewer = next_data["props"]["pageProps"]["payload"]["viewer"]
+      if "payload" in next_data["props"]["pageProps"].keys():
+        self.viewer = next_data["props"]["pageProps"]["payload"]["viewer"]
+      else:
+        self.viewer = next_data["props"]["pageProps"]["data"]["viewer"]
       self.user_id = self.viewer["poeUser"]["id"]
       self.next_data = next_data
 


### PR DESCRIPTION
Fixed a bug, when calling the get_next_data function, viewer does not always appear in next_data[“props”][“pageProps”][“payload”], sometimes it appears in next_data[“props”][“pageProps”][“data”].