### PR TITLE
#63 Get suggested replies

### DIFF
--- a/examples/send_message.py
+++ b/examples/send_message.py
@@ -1,6 +1,7 @@
 import poe
 import logging
 import sys
+import time
 
 #send a message and stream the response
 
@@ -8,7 +9,14 @@ token = sys.argv[1]
 poe.logger.setLevel(logging.INFO)
 client = poe.Client(token)
 
+def callback(suggestion):
+    print("Suggested reply:", suggestion)
+
 message = "Summarize the GNU GPL v3"
-for chunk in client.send_message("capybara", message, with_chat_break=True):
+for chunk in client.send_message("capybara", message, with_chat_break=True, suggest_callback=callback):
   print(chunk["text_new"], end="", flush=True)
 print()
+
+# Suggested replies usually come in a few seconds after the message is fully received
+for i in range(5):
+   time.sleep(1)

--- a/poe-api/src/poe.py
+++ b/poe-api/src/poe.py
@@ -136,6 +136,7 @@ class Client:
 
     self.active_messages = {}
     self.message_queues = {}
+    self.message_suggestions = {}
 
     self.headers = {**headers, **{
       "Referrer": "https://poe.com/",
@@ -473,6 +474,14 @@ class Client:
           continue
         message = message_data["payload"]["data"]["messageAdded"]
 
+        if 'suggestedReplies' in message and type(message['suggestedReplies']) == list and len(message['suggestedReplies']) > 0:
+          suggestion_dict = self.message_suggestions.get(message['messageId'], None)
+          if suggestion_dict != None:
+            new_suggestions = [x for x in message['suggestedReplies'] if x not in suggestion_dict['suggestions']]
+            suggestion_dict['suggestions'].extend(new_suggestions)
+            for suggestion in new_suggestions:
+                suggestion_dict['callback'](suggestion)
+
         copied_dict = self.active_messages.copy()
         for key, value in copied_dict.items():
           #add the message to the appropriate queue
@@ -491,7 +500,7 @@ class Client:
       self.disconnect_ws()
       self.connect_ws()
 
-  def send_message(self, chatbot, message, with_chat_break=False, timeout=20, async_recv=True):
+  def send_message(self, chatbot, message, with_chat_break=False, timeout=20, async_recv=True, suggest_callback=None):
     # if there is another active message, wait until it has finished sending
     timer = 0
     while None in self.active_messages.values():
@@ -556,6 +565,10 @@ class Client:
       message["text_new"] = message["text"][len(last_text):]
       last_text = message["text"]
       message_id = message["messageId"]
+
+      # set a suggestion callback on response
+      if callable(suggest_callback) and self.message_suggestions.get(message_id, None) == None:
+        self.message_suggestions[message_id] = dict(callback=suggest_callback, suggestions=[])
 
       yield message
     


### PR DESCRIPTION
Implements #63 and #149.

Why callbacks? `send_message` ends when the bot reply is fully received and not all bots support suggestions, plus not every user would want this, so it would make sense to return early so that it would not block the thread but return to it later when the actual suggestion is received.