### PR TITLE
Add a simple FastAPI with authentication in examples directory

### DIFF
--- a/examples/poe_fast_api.py
+++ b/examples/poe_fast_api.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import poe
+
+# Initiate FastAPI
+app = FastAPI()
+
+# These tokens are just placeholders for the purpose of this example.
+# In a production environment, you should store these values in environment variables or a secure secrets storage.
+# Import os and use os.getenv('YOUR_ENV_VAR') to get the environment variables.
+API_TOKEN = "your-token"
+POE_TOKEN = "your-token"
+
+# CORS middleware settings
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Security scheme
+security = HTTPBearer()
+
+# Model for message
+class Message(BaseModel):
+    message: str
+
+# Simple auth check
+async def auth_check(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if credentials.scheme != "Bearer" or credentials.credentials != API_TOKEN:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+    return credentials
+
+@app.post("/message")
+async def send_message(message: Message, token: HTTPAuthorizationCredentials = Depends(auth_check)):
+    # Send the message using poe and collect the response
+    client = poe.Client(POE_TOKEN)
+    response = []
+    for chunk in client.send_message("a2", message.message, with_chat_break=True):
+        response.append(chunk["text_new"])
+
+    return {"response": response}
+# install requirements ( FastAPI and uvicorn ) using : pip install -r requirements.txt
+# run using: uvicorn filename:app --reload

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,14 @@
+annotated-types==0.5.0
+anyio==3.7.1
+click==8.1.4
+colorama==0.4.6
+exceptiongroup==1.1.2
+fastapi==0.100.0
+h11==0.14.0
+idna==3.4
+pydantic==2.0.2
+pydantic_core==2.1.2
+sniffio==1.3.0
+starlette==0.27.0
+typing_extensions==4.7.1
+uvicorn==0.22.0


### PR DESCRIPTION
I've added an example of using the poe-api library with FastAPI to create a simple API endpoint that sends a message and returns a response from the POE client.
and also a simple token-based authentication method to protect the API endpoint.
The new dependencies for this example have been added to a requirements.txt file in the same directory as the example.
Please let me know if any modifications are required.